### PR TITLE
special cases for `Input` component for numeric types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sveltestrap/sveltestrap",
   "description": "Bootstrap components for Svelte",
-  "version": "7.0.3",
+  "version": "7.0.3-conduit-fork-1.0.0",
   "license": "MIT",
   "homepage": "https://sveltestrap.js.org",
   "repository": {

--- a/src/Input/Input.svelte
+++ b/src/Input/Input.svelte
@@ -371,7 +371,61 @@
       {readonly}
       {valid}
     />
-  {:else if type === 'date' || type === 'datetime' || type === 'datetime-local' || type === 'month' || type === 'number' || type === 'time' || type === 'range' || type === 'week'}
+  {:else if type === 'number'}
+    <!-- Explicitly declare `type=` to get correct svelte type binding - https://svelte.dev/tutorial/svelte/numeric-inputs -->
+    <input
+      {...$$restProps}
+      type='number'
+      data-bs-theme={theme}
+      class={classes}
+      bind:value
+      bind:this={inner}
+      on:blur
+      on:change
+      on:click
+      on:dblclick
+      on:focus
+      on:input
+      on:keydown
+      on:keypress
+      on:keyup
+      on:mousedown
+      on:mouseup
+      {disabled}
+      {max}
+      {min}
+      {name}
+      {placeholder}
+      {readonly}
+    />
+  {:else if type === 'range'}
+    <!-- Explicitly declare `type=` to get correct svelte type binding - https://svelte.dev/tutorial/svelte/numeric-inputs -->
+    <input
+      {...$$restProps}
+      type='range'
+      data-bs-theme={theme}
+      class={classes}
+      bind:value
+      bind:this={inner}
+      on:blur
+      on:change
+      on:click
+      on:dblclick
+      on:focus
+      on:input
+      on:keydown
+      on:keypress
+      on:keyup
+      on:mousedown
+      on:mouseup
+      {disabled}
+      {max}
+      {min}
+      {name}
+      {placeholder}
+      {readonly}
+    />
+  {:else if type === 'date' || type === 'datetime' || type === 'datetime-local' || type === 'month' || type === 'time' || type === 'week'}
     <input
       {...$$restProps}
       {...{ type }}


### PR DESCRIPTION
svelte requires statically analyzable `type` to get the proper bind value typing https://svelte.dev/tutorial/svelte/numeric-inputs